### PR TITLE
Escape path spaces in XCode project

### DIFF
--- a/ExporterXCode.js
+++ b/ExporterXCode.js
@@ -669,8 +669,8 @@ class ExporterXCode extends Exporter {
 		this.p(");", 4);
 		this.p("HEADER_SEARCH_PATHS = (", 4);
 		this.p('"$(inherited)",', 5);
-		this.p('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,', 5);
-		for (let path of project.getIncludeDirs()) this.p(from.resolve(path).toAbsolutePath().toString() + ",", 5);
+		this.p('"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",', 5);
+		for (let path of project.getIncludeDirs()) this.p('"' + from.resolve(path).toAbsolutePath().toEscapedString() + '",', 5);
 		this.p(");", 4);
 		this.p("INFOPLIST_FILE = \"" + from.resolve(plistname).toAbsolutePath().toString() + "\";", 4);
 		if (platform === Platform.iOS) {
@@ -699,8 +699,8 @@ class ExporterXCode extends Exporter {
 		this.p(");", 4);
 		this.p("HEADER_SEARCH_PATHS = (", 4);
 		this.p('"$(inherited)",', 5);
-		this.p('/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,', 5);
-		for (let path of project.getIncludeDirs()) this.p(from.resolve(path).toAbsolutePath().toString() + ",", 5);
+		this.p('"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",', 5);
+		for (let path of project.getIncludeDirs()) this.p('"' + from.resolve(path).toAbsolutePath().toEscapedString() + '",', 5);
 		this.p(");", 4);
 		this.p("INFOPLIST_FILE = \"" + from.resolve(plistname).toAbsolutePath().toString() + "\";", 4);
 		if (platform === Platform.iOS) {

--- a/Path.js
+++ b/Path.js
@@ -49,6 +49,10 @@ class Path {
 		return pathlib.normalize(this.path);
 	}
 
+	toEscapedString() {
+		return this.toString().replace(/ /g,"\\\\ ");
+	}
+
 	isAbsolute() {
 		return (this.path.length > 0 && this.path[0] == '/') || (this.path.length > 1 && this.path[1] == ':');
 	}


### PR DESCRIPTION
As discussed in issue #9, this change will fix issues when the path koremake is located in contains spaces.