### PR TITLE
Make generated Xcode projects compatible with JetBrains AppCode

### DIFF
--- a/ExporterXCode.js
+++ b/ExporterXCode.js
@@ -319,7 +319,7 @@ class ExporterXCode extends Exporter {
 			else if (framework.toString().endsWith('.dylib')) this.p(framework.getFileId() + " /* " + framework.toString() + " */ = {isa = PBXFileReference; lastKnownFileType = compiled.mach-o.dylib; name = " + framework.toString() + "; path = usr/lib/" + framework.toString() + "; sourceTree = SDKROOT; };", 2);
 			else this.p(framework.getFileId() + " /* " + framework.toString() + " */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = " + framework.toString() + "; path = ../" + from.resolve(framework.toString()).toAbsolutePath().toString() + "; sourceTree = SDKROOT; };", 2);
 		}
-		this.p(debugDirFileId + " /* Deployment */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Deployment; path = \"" + from.resolve(project.getDebugDir()).toAbsolutePath().toString() + "\"; sourceTree = \"<group>\"; };", 2);
+		this.p(debugDirFileId + " /* Deployment */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Deployment; path = \"" + to.relativize(from.resolve(project.getDebugDir())).toString()+ "\"; sourceTree = \"<group>\"; };", 2);
 		for (let file of files) {
 			let filetype = "unknown";
 			let fileencoding = '';
@@ -335,7 +335,7 @@ class ExporterXCode extends Exporter {
 				filetype = 'sourcecode.metal';
 				fileencoding = 'fileEncoding = 4; ';
 			}
-			this.p(file.getFileId() + " /* " + file.toString() + " */ = {isa = PBXFileReference; " + fileencoding + "lastKnownFileType = " + filetype + "; name = \"" + file.getLastName() + "\"; path = \"" + from.resolve(file.toString()).toAbsolutePath().toString() + "\"; sourceTree = \"<group>\"; };", 2);
+			this.p(file.getFileId() + " /* " + file.toString() + " */ = {isa = PBXFileReference; " + fileencoding + "lastKnownFileType = " + filetype + "; name = \"" + file.getLastName() + "\"; path = \"" + from.resolve(file.toString()) + "\"; sourceTree = \"<group>\"; };", 2);
 		}
 		this.p(iconFileId + ' /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };', 2);
 		this.p("/* End PBXFileReference section */");


### PR DESCRIPTION
For some reason, using absolute paths for file and folder references makes AppCode unable to find the files. Folder references need to be relative to the build directory.

Projects created with this pull request are compatible with both XCode (7.3) and AppCode (2006.1). Tested by deleting and recreating the OSX and iOS projects and clean/build/run in each IDE.
