### PR TITLE
output object files on linux build to separate directories

### DIFF
--- a/ExporterMakefile.ts
+++ b/ExporterMakefile.ts
@@ -55,8 +55,8 @@ export class ExporterMakefile extends Exporter {
 				}
 			}
 			if (precompiledHeader !== null) {
-				let realfile = path.relative(outputPath, path.resolve(from, file.file));
-				gchfilelist += realfile + '.gch ';
+				//let realfile = path.relative(outputPath, path.resolve(from, file.file));
+				gchfilelist += path.basename(file.file) + '.gch ';
 			}
 		}
 		
@@ -67,7 +67,7 @@ export class ExporterMakefile extends Exporter {
 		
 		this.writeFile(path.resolve(outputPath, 'makefile'));
 
-		let incline = '';
+		let incline = '-I./ '; // local directory to pick up the precompiled header hxcpp.h.gch
 		for (let inc of project.getIncludeDirs()) {
 			inc = path.relative(outputPath, path.resolve(from, inc));
 			incline += '-I' + inc + ' ';
@@ -109,9 +109,9 @@ export class ExporterMakefile extends Exporter {
 			}
 			if (precompiledHeader !== null) {
 				let realfile = path.relative(outputPath, path.resolve(from, file.file));
-				this.p(realfile + '.gch: ' + realfile);
+				this.p(path.basename(realfile) + '.gch: ' + realfile);
 				let compiler = 'g++';
-				this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + realfile + '.gch $(LIB)');
+				this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + path.basename(file.file) + '.gch $(LIB)');
 			}
 		}
 

--- a/ExporterMakefile.ts
+++ b/ExporterMakefile.ts
@@ -13,9 +13,12 @@ export class ExporterMakefile extends Exporter {
 
 	exportSolution(solution: Solution, from: string, to: string, platform: string, vrApi, nokrafix, options) {
 		let project = solution.getProjects()[0];
-
+		let outputPath = path.resolve(to, options.buildPath);
 		let objects = {};
 		let ofiles = {};
+
+		fs.ensureDirSync(outputPath);
+
 		for (let fileobject of project.getFiles()) {
 			let file = fileobject.file;
 			if (file.endsWith(".cpp") || file.endsWith(".c") || file.endsWith("cc")) {
@@ -52,7 +55,7 @@ export class ExporterMakefile extends Exporter {
 				}
 			}
 			if (precompiledHeader !== null) {
-				let realfile = path.relative(to, path.resolve(from, file.file));
+				let realfile = path.relative(outputPath, path.resolve(from, file.file));
 				gchfilelist += realfile + '.gch ';
 			}
 		}
@@ -62,11 +65,11 @@ export class ExporterMakefile extends Exporter {
 			ofilelist += o + '.o ';
 		}
 		
-		this.writeFile(path.resolve(to, 'makefile'));
+		this.writeFile(path.resolve(outputPath, 'makefile'));
 
 		let incline = '';
 		for (let inc of project.getIncludeDirs()) {
-			inc = path.relative(to, path.resolve(from, inc));
+			inc = path.relative(outputPath, path.resolve(from, inc));
 			incline += '-I' + inc + ' ';
 		}
 		this.p('INC=' + incline);
@@ -105,7 +108,7 @@ export class ExporterMakefile extends Exporter {
 				}
 			}
 			if (precompiledHeader !== null) {
-				let realfile = path.relative(to, path.resolve(from, file.file));
+				let realfile = path.relative(outputPath, path.resolve(from, file.file));
 				this.p(realfile + '.gch: ' + realfile);
 				let compiler = 'g++';
 				this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + realfile + '.gch $(LIB)');
@@ -117,7 +120,7 @@ export class ExporterMakefile extends Exporter {
 			if (file.endsWith('.c') || file.endsWith('.cpp') || file.endsWith('cc')) {
 				this.p();
 				let name = ofiles[file];
-				let realfile = path.relative(to, path.resolve(from, file));
+				let realfile = path.relative(outputPath, path.resolve(from, file));
 				this.p(name + '.o: ' + realfile);
 				let compiler = 'g++';
 				if (file.endsWith('.c')) compiler = 'gcc';

--- a/main.ts
+++ b/main.ts
@@ -242,7 +242,7 @@ function compileProject(make, project, solutionName: string, options): Promise<v
 		make.on('close', function (code) {
 			if (code === 0) {
 				if (options.target === Platform.Linux) {
-					fs.copySync(path.join(options.to.toString(), solutionName), path.join(options.from.toString(), project.getDebugDir(), solutionName), { clobber: true });
+					fs.copySync(path.join(path.join(options.to.toString(), options.buildPath), solutionName), path.join(options.from.toString(), project.getDebugDir(), solutionName), { clobber: true });
 				}
 				else if (options.target === Platform.Windows) {
 					fs.copySync(path.join(options.to.toString(), 'Debug', solutionName + '.exe'), path.join(options.from.toString(), project.getDebugDir(), solutionName + '.exe'), { clobber: true });
@@ -283,6 +283,7 @@ export async function run(options, loglog): Promise<string> {
 	//if (options.vr != undefined) {
 	//	Options.vrApi = options.vr;
 	//}
+	options.buildPath = options.debug ? 'Debug' : 'Release';
 	
 	let solution = exportProject(options.from, options.to, options.target, options);
 	let project = solution.getProjects()[0];
@@ -290,11 +291,11 @@ export async function run(options, loglog): Promise<string> {
 	
 	if (options.compile && solutionName != "") {
 		log.info('Compiling...');
-
+		
 		let make = null;
 
 		if (options.target === Platform.Linux) {
-			make = child_process.spawn('make', [], { cwd: options.to });
+			make = child_process.spawn('make', [], { cwd: path.join(options.to, options.buildPath) });
 		}
 		else if (options.target === Platform.OSX) {
 			make = child_process.spawn('xcodebuild', ['-project', solutionName + '.xcodeproj'], { cwd: options.to });

--- a/out/ExporterMakefile.js
+++ b/out/ExporterMakefile.js
@@ -48,8 +48,8 @@ class ExporterMakefile extends Exporter_1.Exporter {
                 }
             }
             if (precompiledHeader !== null) {
-                let realfile = path.relative(outputPath, path.resolve(from, file.file));
-                gchfilelist += realfile + '.gch ';
+                //let realfile = path.relative(outputPath, path.resolve(from, file.file));
+                gchfilelist += path.basename(file.file) + '.gch ';
             }
         }
         let ofilelist = '';
@@ -57,7 +57,7 @@ class ExporterMakefile extends Exporter_1.Exporter {
             ofilelist += o + '.o ';
         }
         this.writeFile(path.resolve(outputPath, 'makefile'));
-        let incline = '';
+        let incline = '-I./ '; // local directory to pick up the precompiled header hxcpp.h.gch
         for (let inc of project.getIncludeDirs()) {
             inc = path.relative(outputPath, path.resolve(from, inc));
             incline += '-I' + inc + ' ';
@@ -93,9 +93,9 @@ class ExporterMakefile extends Exporter_1.Exporter {
             }
             if (precompiledHeader !== null) {
                 let realfile = path.relative(outputPath, path.resolve(from, file.file));
-                this.p(realfile + '.gch: ' + realfile);
+                this.p(path.basename(realfile) + '.gch: ' + realfile);
                 let compiler = 'g++';
-                this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + realfile + '.gch $(LIB)');
+                this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + path.basename(file.file) + '.gch $(LIB)');
             }
         }
         for (let fileobject of project.getFiles()) {

--- a/out/ExporterMakefile.js
+++ b/out/ExporterMakefile.js
@@ -1,5 +1,6 @@
 "use strict";
 const Exporter_1 = require('./Exporter');
+const fs = require('fs-extra');
 const path = require('path');
 class ExporterMakefile extends Exporter_1.Exporter {
     constructor() {
@@ -7,8 +8,10 @@ class ExporterMakefile extends Exporter_1.Exporter {
     }
     exportSolution(solution, from, to, platform, vrApi, nokrafix, options) {
         let project = solution.getProjects()[0];
+        let outputPath = path.resolve(to, options.buildPath);
         let objects = {};
         let ofiles = {};
+        fs.ensureDirSync(outputPath);
         for (let fileobject of project.getFiles()) {
             let file = fileobject.file;
             if (file.endsWith(".cpp") || file.endsWith(".c") || file.endsWith("cc")) {
@@ -45,7 +48,7 @@ class ExporterMakefile extends Exporter_1.Exporter {
                 }
             }
             if (precompiledHeader !== null) {
-                let realfile = path.relative(to, path.resolve(from, file.file));
+                let realfile = path.relative(outputPath, path.resolve(from, file.file));
                 gchfilelist += realfile + '.gch ';
             }
         }
@@ -53,10 +56,10 @@ class ExporterMakefile extends Exporter_1.Exporter {
         for (let o in objects) {
             ofilelist += o + '.o ';
         }
-        this.writeFile(path.resolve(to, 'makefile'));
+        this.writeFile(path.resolve(outputPath, 'makefile'));
         let incline = '';
         for (let inc of project.getIncludeDirs()) {
-            inc = path.relative(to, path.resolve(from, inc));
+            inc = path.relative(outputPath, path.resolve(from, inc));
             incline += '-I' + inc + ' ';
         }
         this.p('INC=' + incline);
@@ -89,7 +92,7 @@ class ExporterMakefile extends Exporter_1.Exporter {
                 }
             }
             if (precompiledHeader !== null) {
-                let realfile = path.relative(to, path.resolve(from, file.file));
+                let realfile = path.relative(outputPath, path.resolve(from, file.file));
                 this.p(realfile + '.gch: ' + realfile);
                 let compiler = 'g++';
                 this.p('\t' + compiler + ' ' + cpp + ' ' + optimization + ' $(INC) $(DEF) -c ' + realfile + ' -o ' + realfile + '.gch $(LIB)');
@@ -100,7 +103,7 @@ class ExporterMakefile extends Exporter_1.Exporter {
             if (file.endsWith('.c') || file.endsWith('.cpp') || file.endsWith('cc')) {
                 this.p();
                 let name = ofiles[file];
-                let realfile = path.relative(to, path.resolve(from, file));
+                let realfile = path.relative(outputPath, path.resolve(from, file));
                 this.p(name + '.o: ' + realfile);
                 let compiler = 'g++';
                 if (file.endsWith('.c'))

--- a/out/main.js
+++ b/out/main.js
@@ -237,7 +237,7 @@ function compileProject(make, project, solutionName, options) {
         make.on('close', function (code) {
             if (code === 0) {
                 if (options.target === Platform_1.Platform.Linux) {
-                    fs.copySync(path.join(options.to.toString(), solutionName), path.join(options.from.toString(), project.getDebugDir(), solutionName), { clobber: true });
+                    fs.copySync(path.join(path.join(options.to.toString(), options.buildPath), solutionName), path.join(options.from.toString(), project.getDebugDir(), solutionName), { clobber: true });
                 }
                 else if (options.target === Platform_1.Platform.Windows) {
                     fs.copySync(path.join(options.to.toString(), 'Debug', solutionName + '.exe'), path.join(options.from.toString(), project.getDebugDir(), solutionName + '.exe'), { clobber: true });
@@ -274,6 +274,7 @@ function run(options, loglog) {
         //if (options.vr != undefined) {
         //	Options.vrApi = options.vr;
         //}
+        options.buildPath = options.debug ? 'Debug' : 'Release';
         let solution = exportProject(options.from, options.to, options.target, options);
         let project = solution.getProjects()[0];
         let solutionName = solution.getName();
@@ -281,7 +282,7 @@ function run(options, loglog) {
             log.info('Compiling...');
             let make = null;
             if (options.target === Platform_1.Platform.Linux) {
-                make = child_process.spawn('make', [], { cwd: options.to });
+                make = child_process.spawn('make', [], { cwd: path.join(options.to, options.buildPath) });
             }
             else if (options.target === Platform_1.Platform.OSX) {
                 make = child_process.spawn('xcodebuild', ['-project', solutionName + '.xcodeproj'], { cwd: options.to });


### PR DESCRIPTION
to **build/linux-build/Release** (default) or **build/linux-build/Debug** (--debug)

could maybe fix https://github.com/KTXSoftware/Kha/issues/371

Edit: the precompiled header file is now also generated in these directories instead of cluttering ```Kha/Backends/Kore/khacpp/include```