### PR TITLE
Added arm7 build variants to android-native project

### DIFF
--- a/Data/android/app/build.gradle
+++ b/Data/android/app/build.gradle
@@ -28,6 +28,20 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+
+        releaseArm7 {
+            initWith release
+            ndk {
+                abiFilters 'armeabi-v7a'
+            }
+        }
+
+        debugArm7 {
+            initWith debug
+            ndk {
+                abiFilters 'armeabi-v7a'
+            }
+        }
     }
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
It's convenient to have these build variants because otherwise it builds for all abi's and compilation time becomes insane.